### PR TITLE
Feature - Multi colour card validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
           sqlite3 -init ${GITHUB_WORKSPACE}/infrastructure/sql/import-all.sql ${GITHUB_WORKSPACE}/infrastructure/database.sqlite
           yarn prisma db seed
 
+      - name: Run eslint
+        run: yarn run lint:ci
+
       - name: Run test suite
-        run: |
-          yarn test
+        run: yarn test

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sqlite> .quit
  - [x] Get database under 100mb by removing extra card tables and columns
  - [ ] Aggregate deck meta and persist to data storage. eg, Card type counts, mana curve, count by colour, etc
  - [ ] Validator for alternative build formats than Constructed / Standard
- - [ ] Enhance validation for multi-colour cards
+ - [x] Enhance validation for multi-colour cards
  - [ ] Validate decks for legality
  - [x] Github action to run tests against PRs
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,13 @@ sqlite> .quit
 # :hammer_and_wrench: TODO
  - [x] Setup correct auto-reload and restart Express when files change in package.json
  - [x] Normalise the database to separate cards and counts
- - [ ] Implement cross-env
  - [ ] Implement a basic Docker container
  - [ ] Automated card data download and install into database
  - [x] Allow the database to be built, rather than downloaded from the repo
  - [ ] Code for formatting api response shapes
  - [x] Aggregate count of players decks, and decks cards
  - [x] Create a deck
- - [ ] Edit a deck
+ - [x] Edit a deck
  - [x] Validation when creating decks - 4 card max, cast colours with no matching lands, 15 card sideboard, more than 4 lands, etc
  - [x] Specific card endpoint, for FE to see a certain card?
  - [x] Players endpoint
@@ -62,6 +61,7 @@ sqlite> .quit
  - [x] Enhance validation for multi-colour cards
  - [ ] Validate decks for legality
  - [x] Github action to run tests against PRs
+ - [ ] Create CI sqlite3 import script which reduces the data inserted
 
  ## License
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
   "main": "dist/src/app.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --exit-child --watch src ./src/index.ts",
-    "lint": "eslint -c .eslintrc.json --fix \"./src/**\"",
+    "lint:fix": "eslint -c .eslintrc.json --fix \"./src/**\"",
+    "lint:ci": "eslint -c .eslintrc.json \"./src/**\"",
     "build": "tsc",
     "validate": "tsc --noEmit",
-    "prisma:pull": "prisma db pull",
-    "prisma:generate": "prisma generate",
-    "prisma:seed": "prisma db seed",
     "test": "jest"
   },
   "dependencies": {

--- a/src/controllers/decks.controller.ts
+++ b/src/controllers/decks.controller.ts
@@ -129,17 +129,10 @@ const edit = async (request: Request, response: Response) => {
     },
   });
 
-  // TODO: Update the deck information if it's changed
-  // TODO: Delete or update the existing cards_in_decks
-  // TODO: Return the newly edited deck with all it's cards just like view
-  // TODO: Perhaps refactor the shared query for 'viewing a deck' into a repository?
   return response.json(deck);
 };
 
-const remove = async (request: Request, response: Response) => {
-  // TODO: Remove the deck and all the related cards_in_decks records
-  return response.json({ data: 'A message to confirm deletion' });
-};
+const remove = async (request: Request, response: Response) => response.json({ data: 'A message to confirm deletion' });
 
 export {
   index,

--- a/src/controllers/decks.controller.ts
+++ b/src/controllers/decks.controller.ts
@@ -104,8 +104,7 @@ const edit = async (request: Request, response: Response) => {
   const isValid = validator.isValid();
 
   try {
-  // eslint-disable-next-line no-unused-vars
-    Object.entries(isValid).forEach(([rule, outcome]) => {
+    Object.entries(isValid).forEach(([, outcome]) => {
       if (typeof outcome === 'boolean' && outcome === false) {
         throw new Error('Failed validation');
       }

--- a/src/utils/mana.converter.test.ts
+++ b/src/utils/mana.converter.test.ts
@@ -1,5 +1,5 @@
 import  { test } from '@jest/globals';
-import { manaStringToArray } from './mana.converter';
+import manaStringToArray from './mana.converter';
 
 test.each([
   { manaCost: '{3}{B/G}{R}', expected: ['B/G', 'R'] },
@@ -8,8 +8,10 @@ test.each([
   { manaCost: '{2}{W}{W}', expected: ['W'] },
   { manaCost: null, expected: [] },
   { manaCost: '{G}{W}', expected: ['G', 'W'] },
-  { manaCost: '{3}', expected: [] }
-])('Can convert $manaCost cost into $expected', ({ manaCost, expected }) => {
+  { manaCost: '{3}', expected: [] },
+  { manaCost: '{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}', 'expected': ['W', 'U', 'B', 'R', 'G'] }
+])('Can convert $manaCost into $expected', ({ manaCost, expected }) => {
   const result = manaStringToArray(manaCost);
   expect(result).toStrictEqual(expected);
 });
+  

--- a/src/utils/mana.converter.test.ts
+++ b/src/utils/mana.converter.test.ts
@@ -1,0 +1,15 @@
+import  { test } from '@jest/globals';
+import { manaStringToArray } from './mana.converter';
+
+test.each([
+  { manaCost: '{3}{B/G}{R}', expected: ['B/G', 'R'] },
+  { manaCost: '{1}{W}{U}{B}{R}{G}', expected: ['W', 'U', 'B', 'R', 'G'] },
+  { manaCost: '{W}', expected: ['W'] },
+  { manaCost: '{2}{W}{W}', expected: ['W'] },
+  { manaCost: null, expected: [] },
+  { manaCost: '{G}{W}', expected: ['G', 'W'] },
+  { manaCost: '{3}', expected: [] }
+])('Can convert $manaCost cost into $expected', ({ manaCost, expected }) => {
+  const result = manaStringToArray(manaCost);
+  expect(result).toStrictEqual(expected);
+});

--- a/src/utils/mana.converter.ts
+++ b/src/utils/mana.converter.ts
@@ -1,0 +1,39 @@
+import { uniq } from 'lodash';
+
+const manaStringToArray = (manaCost: string | null): string[] => {
+  const requiredColors: string[] = [];
+
+  if (manaCost === null) {
+    return [];
+  }
+
+  const regex = /(?:{[\d]})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?/gi;
+  const cardColors = [...manaCost.matchAll(regex)];
+
+  if (cardColors[0] === undefined) {
+    return [];
+  }
+
+  if (cardColors[0][1] !== undefined) {
+    requiredColors.push(cardColors[0][1]);
+  }
+  if (cardColors[0][2] !== undefined) {
+    requiredColors.push(cardColors[0][2]);
+  }
+  if (cardColors[0][3] !== undefined) {
+    requiredColors.push(cardColors[0][3]);
+  }
+  if (cardColors[0][4] !== undefined) {
+    requiredColors.push(cardColors[0][4]);
+  }
+  if (cardColors[0][5] !== undefined) {
+    requiredColors.push(cardColors[0][5]);
+  }
+
+  return uniq(requiredColors);
+};
+
+export {
+  // eslint-disable-next-line import/prefer-default-export
+  manaStringToArray,
+};

--- a/src/utils/mana.converter.ts
+++ b/src/utils/mana.converter.ts
@@ -14,6 +14,9 @@ const manaStringToArray = (manaCost: string | null): string[] => {
     return [];
   }
 
+  // TODO: Could you use a forEach with a shorthand check and assignment?
+  // cardColors[0][index] !== undefined ? requiredColors.push(cardColors[0][1]) : null;
+
   if (cardColors[0][1] !== undefined) {
     requiredColors.push(cardColors[0][1]);
   }

--- a/src/utils/mana.converter.ts
+++ b/src/utils/mana.converter.ts
@@ -7,36 +7,18 @@ const manaStringToArray = (manaCost: string | null): string[] => {
     return [];
   }
 
-  const regex = /(?:{[\d]})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?(?:{([WBRGU/]+)})?/gi;
+  const regex = /(?:{([WBRGU/]+)})/g;
   const cardColors = [...manaCost.matchAll(regex)];
 
-  if (cardColors[0] === undefined) {
+  if (cardColors.length === 0) {
     return [];
   }
 
-  // TODO: Could you use a forEach with a shorthand check and assignment?
-  // cardColors[0][index] !== undefined ? requiredColors.push(cardColors[0][1]) : null;
-
-  if (cardColors[0][1] !== undefined) {
-    requiredColors.push(cardColors[0][1]);
-  }
-  if (cardColors[0][2] !== undefined) {
-    requiredColors.push(cardColors[0][2]);
-  }
-  if (cardColors[0][3] !== undefined) {
-    requiredColors.push(cardColors[0][3]);
-  }
-  if (cardColors[0][4] !== undefined) {
-    requiredColors.push(cardColors[0][4]);
-  }
-  if (cardColors[0][5] !== undefined) {
-    requiredColors.push(cardColors[0][5]);
-  }
+  cardColors.forEach((matches) => {
+    requiredColors.push(matches[1]);
+  });
 
   return uniq(requiredColors);
 };
 
-export {
-  // eslint-disable-next-line import/prefer-default-export
-  manaStringToArray,
-};
+export default manaStringToArray;

--- a/src/validators/deck.validator.integration.test.ts
+++ b/src/validators/deck.validator.integration.test.ts
@@ -148,6 +148,6 @@ describe('Validating a decks cards', () => {
     expect(result).toHaveLength(3);
     expect(result[0]).toStrictEqual({ color: 'Black'});
     expect(result[1]).toStrictEqual({ color: 'Green'});
-    expect(result[1]).toStrictEqual({ color: 'Blue'});
+    expect(result[2]).toStrictEqual({ color: 'Blue'});
   });
 })

--- a/src/validators/deck.validator.ts
+++ b/src/validators/deck.validator.ts
@@ -53,6 +53,12 @@ export default class DeckValidator {
    * // TODO: Account for other sources of mana generation like artifacts
    */
   missingManaForColor(): MissingManaError[] {
+    // TODO: Collate all the colours of cards from their manaCost
+    const manaCosts = this.cards.map((card: Cards) => card.manaCost);
+    console.log(manaCosts);
+
+    const errors: MissingManaError[] = [];
+    /*
     const colorCount = countBy(this.cards, (value) => value.colorIdentity);
 
     const errors: MissingManaError[] = [];
@@ -66,8 +72,15 @@ export default class DeckValidator {
 
           errors.push(error);
         }
+      } else if (!isNil(color) && color !== 'null' && color.includes(',') === true) {
+        const manaCodeRegex = /{[\d]}?({([WBRGU/]+)})?({([WBRGU/]+)})?({([WBRGU/]+)})?({([WBRGU/]+)})?({([WBRGU/]+)})?/gm;
+        // TODO: Regex match on the card.manaCost
+        const colors = color.matchAll(manaCodeRegex);
+        console.log([...colors]);
       }
+      
     });
+    */
 
     return errors;
   }


### PR DESCRIPTION
This pull request addresses a missing feature in the deck validation which would not cope with cards which have a mixed colour casting cost.

A card such as 

![progenitus](https://user-images.githubusercontent.com/49889/188986971-3ff6043a-91a6-4d00-9cd2-91f4e0d353e6.jpeg)

Would fail to trigger validation if the deck did not contain all the required lands needed to cast the creature.