### PR TITLE
Created a first draft deck importer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/src/app.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --exit-child --watch src ./src/index.ts",
-    "lint:fix": "eslint -c .eslintrc.json --fix \"./src/**\"",
-    "lint:ci": "eslint -c .eslintrc.json \"./src/**\"",
+    "lint:fix": "eslint -c .eslintrc.json --fix \"./src/**/*.ts\"",
+    "lint:ci": "eslint -c .eslintrc.json \"./src/**/*.ts\"",
     "build": "tsc",
     "validate": "tsc --noEmit",
     "test": "jest",

--- a/src/tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec
+++ b/src/tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec
@@ -1,0 +1,47 @@
+//4 Color Omnath a Modern deck by Antoine57437
+
+1 Eternal Witness
+3 Ice-Fang Coatl
+4 Solitude
+4 Omnath, Locus of Creation
+4 Mishra's Bauble
+1 Unholy Heat
+1 Shadow Prophecy
+2 Ephemerate
+4 Drown in the Loch
+4 Counterspell
+1 Time Warp
+4 Traverse the Ulvenwald
+4 Expressive Iteration
+4 Leyline Binding
+4 Abundant Growth
+4 Teferi, Time Raveler
+4 Wrenn and Six
+1 Watery Grave
+1 Snow-Covered Mountain
+1 Snow-Covered Forest
+1 Sacred Foundry
+1 Raffine's Tower
+1 Prairie Stream
+1 Ketria Triome
+1 Breeding Pool
+2 Snow-Covered Island
+2 Windswept Heath
+2 Wooded Foothills
+2 Boseiju, Who Endures
+3 Flooded Strand
+4 Misty Rainforest
+4 Scalding Tarn
+
+// Sideboard:
+
+SB: 1 Yorion, Sky Nomad
+SB: 1 Emrakul, the Promised End
+SB: 1 Kataki, War's Wage
+SB: 1 Magus of the Moon
+SB: 1 Sanctifier en-Vec
+SB: 1 Snow-Covered Plains
+SB: 1 Surgical Extraction
+SB: 1 Sundering Titan
+SB: 3 Invasive Surgery
+SB: 4 Veil of Summer

--- a/src/tests/fixtures/decks/Burn a Modern deck by Michael Barnes.dec
+++ b/src/tests/fixtures/decks/Burn a Modern deck by Michael Barnes.dec
@@ -1,0 +1,29 @@
+//Burn a Modern deck by Michael Barnes
+
+4 Monastery Swiftspear
+4 Goblin Guide
+4 Eidolon of the Great Revel
+2 Skullcrack
+3 Lightning Helix
+4 Lightning Bolt
+4 Boros Charm
+4 Searing Blaze
+4 Lava Spike
+4 Skewer the Critics
+4 Rift Bolt
+2 Mountain
+3 Bloodstained Mire
+3 Wooded Foothills
+3 Sacred Foundry
+4 Inspiring Vantage
+4 Sunbaked Canyon
+
+// Sideboard:
+
+SB: 2 Exquisite Firecraft
+SB: 2 Rest in Peace
+SB: 2 Wear/Tear
+SB: 2 Smash to Smithereens
+SB: 2 Deflecting Palm
+SB: 2 Path to Exile
+SB: 3 Roiling Vortex

--- a/src/tests/fixtures/decks/Izzet Murktide a Modern deck by Notoriouss.dec
+++ b/src/tests/fixtures/decks/Izzet Murktide a Modern deck by Notoriouss.dec
@@ -1,0 +1,36 @@
+//Izzet Murktide a Modern deck by Notoriouss
+
+3 Dragon's Rage Channeler
+3 Murktide Regent
+3 Ledger Shredder
+4 Ragavan, Nimble Pilferer
+4 Mishra's Bauble
+1 Spell Snare
+2 Spell Pierce
+2 Archmage's Charm
+3 Lightning Bolt
+4 Unholy Heat
+4 Counterspell
+4 Consider
+4 Expressive Iteration
+1 Polluted Delta
+1 Fiery Islet
+1 Otawara, Soaring City
+2 Misty Rainforest
+2 Scalding Tarn
+2 Flooded Strand
+3 Snow-Covered Island
+3 Steam Vents
+4 Spirebluff Canal
+
+// Sideboard:
+
+SB: 1 Unlicensed Hearse
+SB: 1 Tormod's Crypt
+SB: 1 Jace, the Mind Sculptor
+SB: 2 Subtlety
+SB: 2 Mystical Dispute
+SB: 2 Flusterstorm
+SB: 2 Engineered Explosives
+SB: 2 Dress Down
+SB: 2 Blood Moon

--- a/src/utils/import.deck.test.ts
+++ b/src/utils/import.deck.test.ts
@@ -16,7 +16,23 @@ describe('Importing a deck', () => {
     expect(result.cardsInDeck.filter((card) => card.is_sideboard === true)).toHaveLength(9);
   });
 
-  it('should fail to import `4 Color Omnath` from file for missing card', async () => {
-    expect(async () => await importDeck('../tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec')).rejects.toThrowError();
+  it('should import `4 Color Omnath` from file with missing cards', async () => {
+    const result = await importDeck('../tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec');
+
+    expect(result.deck.name).toEqual('4 Color Omnath a Modern deck by Antoine57437');
+    expect(result.cardsInDeck).toHaveLength(40);
+    expect(result.cardsNotFound).toHaveLength(2);
+    expect(result.cardsInDeck.filter((card) => card.is_sideboard === false)).toHaveLength(30);
+    expect(result.cardsInDeck.filter((card) => card.is_sideboard === true)).toHaveLength(10);
+  });
+
+  it('should import `Burn` from file with missing cards', async () => {
+    const result = await importDeck('../tests/fixtures/decks/Burn a Modern deck by Michael Barnes.dec');
+
+    expect(result.deck.name).toEqual('Burn a Modern deck by Michael Barnes');
+    expect(result.cardsInDeck).toHaveLength(23);
+    expect(result.cardsNotFound).toHaveLength(1);
+    expect(result.cardsInDeck.filter((card) => card.is_sideboard === false)).toHaveLength(17);
+    expect(result.cardsInDeck.filter((card) => card.is_sideboard === true)).toHaveLength(6);
   });
 });

--- a/src/utils/import.deck.test.ts
+++ b/src/utils/import.deck.test.ts
@@ -1,0 +1,12 @@
+import importDeck from './import.deck';
+
+describe('Importing a deck', () => {
+  it('should find all the cards', async () => {
+    const result = await importDeck();
+
+    expect(result.deck.name).toEqual('Izzet Murktide a Modern deck by Notoriouss');
+    expect(result.cardsInDeck).toHaveLength(31);
+    expect(result.cardsInDeck.map((card) => card.is_sideboard === false)).toHaveLength(22);
+    expect(result.cardsInDeck.map((card) => card.is_sideboard === true)).toHaveLength(9);
+  });
+});

--- a/src/utils/import.deck.test.ts
+++ b/src/utils/import.deck.test.ts
@@ -1,8 +1,8 @@
 import importDeck from './import.deck';
 
 describe('Importing a deck', () => {
-  it('should import from `.dec` file', async () => {
-    const result = await importDeck();
+  it('should import `Izzet Murktide` from file', async () => {
+    const result = await importDeck('../tests/fixtures/decks/Izzet Murktide a Modern deck by Notoriouss.dec');
 
     expect(result.deck.name).toEqual('Izzet Murktide a Modern deck by Notoriouss');
     expect(result.cardsInDeck).toHaveLength(31);
@@ -14,5 +14,9 @@ describe('Importing a deck', () => {
     })
     expect(result.cardsInDeck.filter((card) => card.is_sideboard === false)).toHaveLength(22);
     expect(result.cardsInDeck.filter((card) => card.is_sideboard === true)).toHaveLength(9);
+  });
+
+  it('should fail to import `4 Color Omnath` from file for missing card', async () => {
+    expect(async () => await importDeck('../tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec')).rejects.toThrowError();
   });
 });

--- a/src/utils/import.deck.test.ts
+++ b/src/utils/import.deck.test.ts
@@ -1,12 +1,18 @@
 import importDeck from './import.deck';
 
 describe('Importing a deck', () => {
-  it('should find all the cards', async () => {
+  it('should import from `.dec` file', async () => {
     const result = await importDeck();
 
     expect(result.deck.name).toEqual('Izzet Murktide a Modern deck by Notoriouss');
     expect(result.cardsInDeck).toHaveLength(31);
-    expect(result.cardsInDeck.map((card) => card.is_sideboard === false)).toHaveLength(22);
-    expect(result.cardsInDeck.map((card) => card.is_sideboard === true)).toHaveLength(9);
+    expect(result.cardsInDeck[0]).toEqual({
+      card_name: 'Dragon\'s Rage Channeler',
+      card_id: 38055,
+      quantity: 3,
+      is_sideboard: false
+    })
+    expect(result.cardsInDeck.filter((card) => card.is_sideboard === false)).toHaveLength(22);
+    expect(result.cardsInDeck.filter((card) => card.is_sideboard === true)).toHaveLength(9);
   });
 });

--- a/src/utils/import.deck.ts
+++ b/src/utils/import.deck.ts
@@ -20,8 +20,6 @@ type ImportedDeck = {
   cardsInDeck: ImportedCardInDeck[]
 }
 
-const filePath = '../tests/fixtures/decks';
-
 const findCard = async (
   cardName: string,
   quantity: number,
@@ -50,8 +48,8 @@ const findCard = async (
   }
 };
 
-const importDeck = async (): Promise<ImportedDeck> => {
-  const deckFile = path.resolve(__dirname, filePath, 'Izzet Murktide a Modern deck by Notoriouss.dec');
+const importDeck = async (filePath: string): Promise<ImportedDeck> => {
+  const deckFile = path.resolve(__dirname, filePath);
   const fileStream = fs.createReadStream(deckFile);
 
   const rl = readline.createInterface({

--- a/src/utils/import.deck.ts
+++ b/src/utils/import.deck.ts
@@ -82,32 +82,31 @@ const importDeck = async (): Promise<ImportedDeck> => {
       continue;
     }
 
-    // TODO: Refactor this duplicated code
+    const regexes = {
+      deck: /^([\d]){1,2}\s(.*)$/ig,
+      sideboard: /^SB:\s([\d]){1,2}\s(.*)$/ig,
+    };
 
-    // Cope with the bulk of the deck, which should be 'Quantity Name'
-    const deckMatches = line.matchAll(/^([\d]){1,2}\s(.*)$/ig);
-    if (deckMatches !== null) {
-      const quantityAndName = [...deckMatches];
-      if (quantityAndName.length > 0) {
-        deckData.cardsInDeck.push(await findCard(
-          quantityAndName[0][2],
-          parseInt(quantityAndName[0][1], 10),
-          false,
-        ));
+    // Detect the type of line
+    let isSideboard = false;
+    let matchesIterator = line.matchAll(regexes.deck);
+    let matchesArray = [...matchesIterator];
+
+    if (matchesArray.length === 0) {
+      matchesIterator = line.matchAll(regexes.sideboard);
+      matchesArray = [...matchesIterator];
+      if (matchesArray.length > 0) {
+        isSideboard = true;
       }
     }
 
-    // Cope with the sideboard, which should be 'SB: Quantity Name'
-    const sideboardMatches = line.matchAll(/^SB:\s([\d]){1,2}\s(.*)$/ig);
-    if (sideboardMatches !== null) {
-      const sideboardQuantityAndName = [...sideboardMatches];
-      if (sideboardQuantityAndName.length > 0) {
-        deckData.cardsInDeck.push(await findCard(
-          sideboardQuantityAndName[0][2],
-          parseInt(sideboardQuantityAndName[0][1], 10),
-          true,
-        ));
-      }
+    // Build and push the object
+    if (matchesArray.length > 0) {
+      deckData.cardsInDeck.push(await findCard(
+        matchesArray[0][2],
+        parseInt(matchesArray[0][1], 10),
+        isSideboard,
+      ));
     }
   }
 

--- a/src/utils/import.deck.ts
+++ b/src/utils/import.deck.ts
@@ -1,0 +1,115 @@
+/* eslint-disable no-continue */
+
+import { CardsInDeck, Deck } from '@prisma/client';
+
+import fs = require('fs')
+import path = require('path')
+import readline = require('readline');
+import prismaClient from '../../prisma/client';
+
+type ImportedCardInDeck = {
+  card_name: string | null,
+  card_id: CardsInDeck['id'],
+  quantity: CardsInDeck['quantity'],
+  is_sideboard: CardsInDeck['is_sideboard']
+}
+
+type ImportedDeck = {
+  deck: {
+    name: Deck['name']
+  },
+  cardsInDeck: ImportedCardInDeck[]
+}
+
+const filePath = '../tests/fixtures/decks';
+
+const findCard = async (
+  cardName: string,
+  quantity: number,
+  sideboard: boolean,
+): Promise<ImportedCardInDeck> => {
+  try {
+    const card = await prismaClient.card.findFirstOrThrow({
+      select: { id: true, name: true },
+      where: {
+        name: cardName,
+        availability: { contains: 'paper' },
+      },
+    });
+
+    return {
+      card_id: card.id,
+      card_name: card.name,
+      quantity,
+      is_sideboard: sideboard,
+    };
+  } catch (error) {
+    // TODO: Handle errors in a better way
+    // TODO: How to lookup double faced cards? Like https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=540967
+    throw new Error(`Tried find a card named "${cardName}" but didn't find it`);
+  }
+};
+
+const importDeck = async (): Promise<ImportedDeck> => {
+  const deckFile = path.resolve(__dirname, filePath, 'Izzet Murktide a Modern deck by Notoriouss.dec');
+  const fileStream = fs.createReadStream(deckFile);
+
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  });
+
+  const deckData: ImportedDeck = {
+    deck: {
+      name: '',
+    },
+    cardsInDeck: [],
+  };
+
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const line of rl) {
+    if (line === '') {
+      continue;
+    }
+
+    // Try and grab the title from the first line of the file
+    if (line.startsWith('//') && !line.startsWith('// ')) {
+      const matches = line.match(/\/\/(.*)/i);
+      if (matches !== null) {
+        // eslint-disable-next-line prefer-destructuring
+        deckData.deck.name = matches[1];
+      }
+      continue;
+    }
+
+    // Cope with the sideboard, which should be 'SB: Quantity Name'
+    const sideboardMatches = line.matchAll(/^SB:\s([\d]){1,2}\s(.*)$/ig);
+    if (sideboardMatches !== null) {
+      const sideboardQuantityAndName = [...sideboardMatches];
+      if (sideboardQuantityAndName.length === 0) continue;
+
+      deckData.cardsInDeck.push(await findCard(
+        sideboardQuantityAndName[0][2],
+        parseInt(sideboardQuantityAndName[0][2], 10),
+        true,
+      ));
+    }
+
+    // Cope with the bulk of the deck, which should be 'Quantity Name'
+    const deckMatches = line.matchAll(/^([\d]){1,2}\s(.*)$/ig);
+    if (deckMatches !== null) {
+      const quantityAndName = [...deckMatches];
+      if (quantityAndName.length === 0) continue;
+
+      deckData.cardsInDeck.push(await findCard(
+        quantityAndName[0][2],
+        parseInt(quantityAndName[0][2], 10),
+        false,
+      ));
+    }
+  }
+
+  return deckData;
+};
+
+export default importDeck;


### PR DESCRIPTION
## What is the change you are proposing?
Adding a way to import `.dec` files into the database, primarily for integration testing, but in the future could be used for users on the front-end to drop a file in to create a whole deck.

## Why is this change needed?
It would allow very quick and easy way for integration and unit tests, to create a complete and valid deck, rather than having to try and build it manually in the tests

## Does this resolve any issues?
Resolves #32 
