### PR TITLE
Refactor seeding

### DIFF
--- a/infrastructure/setup-db.sh
+++ b/infrastructure/setup-db.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set +x
+
+FILE=.env
+if [ ! -f "$FILE" ]; then
+    echo "$FILE does not exist, please copy the `.env.example` file"
+fi
+
+yarn prisma db push
+sqlite3 -init ./infrastructure/sql/cards.sql ./infrastructure/database.sqlite
+yarn prisma db seed

--- a/infrastructure/sql/import-all.sql
+++ b/infrastructure/sql/import-all.sql
@@ -1,6 +1,8 @@
+.progress 20000
 -- .read ./infrastructure/sql/_sets_.sql
 .read ./infrastructure/sql/cards.sql
 -- .read ./infrastructure/sql/legalities.sql
 -- .read ./infrastructure/sql/meta.sql
 -- .read ./infrastructure/sql/rulings.sql
 -- .read ./infrastructure/sql/tokens.sql
+.quit

--- a/src/utils/import.deck.test.ts
+++ b/src/utils/import.deck.test.ts
@@ -7,7 +7,6 @@ describe('Importing a deck', () => {
     expect(result.deck.name).toEqual('Izzet Murktide a Modern deck by Notoriouss');
     expect(result.cardsInDeck).toHaveLength(31);
     expect(result.cardsInDeck[0]).toEqual({
-      card_name: 'Dragon\'s Rage Channeler',
       card_id: 38055,
       quantity: 3,
       is_sideboard: false

--- a/src/utils/import.deck.test.ts
+++ b/src/utils/import.deck.test.ts
@@ -2,7 +2,7 @@ import importDeck from './import.deck';
 
 describe('Importing a deck', () => {
   it('should import `Izzet Murktide` from file', async () => {
-    const result = await importDeck('../tests/fixtures/decks/Izzet Murktide a Modern deck by Notoriouss.dec');
+    const result = await importDeck('../src/tests/fixtures/decks/Izzet Murktide a Modern deck by Notoriouss.dec');
 
     expect(result.deck.name).toEqual('Izzet Murktide a Modern deck by Notoriouss');
     expect(result.cardsInDeck).toHaveLength(31);
@@ -17,7 +17,7 @@ describe('Importing a deck', () => {
   });
 
   it('should import `4 Color Omnath` from file with missing cards', async () => {
-    const result = await importDeck('../tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec');
+    const result = await importDeck('../src/tests/fixtures/decks/4 Color Omnath a Modern deck by Antoine57437.dec');
 
     expect(result.deck.name).toEqual('4 Color Omnath a Modern deck by Antoine57437');
     expect(result.cardsInDeck).toHaveLength(40);
@@ -27,7 +27,7 @@ describe('Importing a deck', () => {
   });
 
   it('should import `Burn` from file with missing cards', async () => {
-    const result = await importDeck('../tests/fixtures/decks/Burn a Modern deck by Michael Barnes.dec');
+    const result = await importDeck('../src/tests/fixtures/decks/Burn a Modern deck by Michael Barnes.dec');
 
     expect(result.deck.name).toEqual('Burn a Modern deck by Michael Barnes');
     expect(result.cardsInDeck).toHaveLength(23);

--- a/src/utils/mana.converter.ts
+++ b/src/utils/mana.converter.ts
@@ -1,5 +1,10 @@
 import { uniq } from 'lodash';
 
+/**
+ * Convert a letter mana casting cost into an array of colors
+ *
+ * eg, `{1}{W}{G}` becomes `['W', 'G']`
+ */
 const manaStringToArray = (manaCost: string | null): string[] => {
   const requiredColors: string[] = [];
 


### PR DESCRIPTION
## What is the change you are proposing?
Add into the seeding script some imported decks, so that one user has a complete deck, and also a deck with missing cards.

## Why is this change needed?

- Adds more data use-cases to the seeding which will help build the front-end.
- Creates a use-case for developing more around how to store cards in a deck which are missing from the database


## Does this resolve any issues?
Resolves #35 
