### PR TITLE
Fixed a few inconsistent data types highlighted by Postman

### DIFF
--- a/openapi-dist.yaml
+++ b/openapi-dist.yaml
@@ -32,19 +32,20 @@ paths:
                 additionalProperties: false
                 properties:
                   data:
-                    type: object
-                    additionalProperties: false
-                    properties:
-                      deck:
-                        $ref: '#/components/schemas/Deck'
-                      player:
-                        $ref: '#/components/schemas/Player'
-                      meta:
-                        type: object
-                        additionalProperties: false
-                        properties:
-                          card_count:
-                            type: integer
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        deck:
+                          $ref: '#/components/schemas/Deck'
+                        player:
+                          $ref: '#/components/schemas/Player'
+                        meta:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            card_count:
+                              type: integer
       parameters: []
       tags:
         - decks
@@ -115,7 +116,9 @@ paths:
                       player:
                         $ref: '#/components/schemas/Player'
                       cards_in_deck:
-                        $ref: '#/components/schemas/CardsInDeck'
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CardsInDeck'
         '404':
           $ref: '#/components/responses/GenericError'
       tags:
@@ -372,7 +375,7 @@ components:
       additionalProperties: false
       properties:
         id:
-          type: string
+          type: integer
           readOnly: true
         border_color:
           type: string

--- a/openapi/resources/decks/deck.yaml
+++ b/openapi/resources/decks/deck.yaml
@@ -27,7 +27,9 @@ get:
                   player:
                     $ref: '../../schemas/player.yaml'
                   cards_in_deck:
-                    $ref: '../../schemas/cards-in-deck.yaml'
+                    type: array
+                    items:
+                      $ref: '../../schemas/cards-in-deck.yaml'
     '404':
       $ref: '../../responses/generic-error.yaml'
   tags:

--- a/openapi/resources/decks/decks.yaml
+++ b/openapi/resources/decks/decks.yaml
@@ -12,19 +12,20 @@ get:
             additionalProperties: false
             properties:
               data: 
-                type: object
-                additionalProperties: false
-                properties:
-                  deck:
-                    $ref: '../../schemas/deck.yaml'
-                  player:
-                    $ref: '../../schemas/player.yaml'
-                  meta:
-                    type: object
-                    additionalProperties: false
-                    properties:
-                      card_count:
-                        type: integer
+                type: array
+                items:
+                  type: object
+                  properties:
+                    deck:
+                      $ref: '../../schemas/deck.yaml'
+                    player:
+                      $ref: '../../schemas/player.yaml'
+                    meta:
+                      type: object
+                      additionalProperties: false
+                      properties:
+                        card_count:
+                          type: integer
   parameters: []
   tags:
     - decks

--- a/openapi/schemas/card.yaml
+++ b/openapi/schemas/card.yaml
@@ -4,7 +4,7 @@ type: object
 additionalProperties: false
 properties:
   id:
-    type: string
+    type: integer
     readOnly: true
   border_color:
     type: string


### PR DESCRIPTION
## What is the change you are proposing?
Running some api endpoints in Postman highlighted that some of the collections `data` properties were `object` instead of `array`

## Why is this change needed?
Ensure the schema is representative of the response shape

## Does this resolve any issues?
No
