### PR TITLE
Bugfix decks card count

### DIFF
--- a/openapi-dist.yaml
+++ b/openapi-dist.yaml
@@ -362,8 +362,9 @@ components:
         name:
           type: string
           readOnly: true
-        updated_ago:
+        updated:
           type: string
+          format: date-time
           readOnly: true
       required:
         - id
@@ -551,6 +552,8 @@ components:
               error:
                 type: object
                 required:
+                  - message
+                  - code
                   - hasLands
                   - missingManaForColor
                   - fourOrMore
@@ -602,6 +605,9 @@ components:
               data:
                 type: object
                 readOnly: true
+                required:
+                  - message
+                  - code
               error:
                 type: object
                 additionalProperties: false

--- a/openapi/schemas/deck.yaml
+++ b/openapi/schemas/deck.yaml
@@ -9,8 +9,9 @@ properties:
   name:
     type: string
     readOnly: true
-  updated_ago:
+  updated:
     type: string
+    format: date-time
     readOnly: true
 required:
   - id

--- a/src/encoders/card.encoder.ts
+++ b/src/encoders/card.encoder.ts
@@ -1,4 +1,4 @@
-import { Card } from '@prisma/client';
+import type { Card } from '@prisma/client';
 
 const cardEncoder = (card: Card) => ({
   id: card.id,

--- a/src/encoders/cardInDeck.encoder.ts
+++ b/src/encoders/cardInDeck.encoder.ts
@@ -1,4 +1,4 @@
-import { Card, CardsInDeck } from '@prisma/client';
+import type { Card, CardsInDeck } from '@prisma/client';
 import cardEncoder from './card.encoder';
 
 type CardsInDecksWithCards = CardsInDeck & { cards: Card };

--- a/src/encoders/deck.encoder.ts
+++ b/src/encoders/deck.encoder.ts
@@ -1,13 +1,10 @@
-import { Deck } from '@prisma/client';
+import type { Deck } from '@prisma/client';
 import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
 
-dayjs.extend(relativeTime);
-
-const deckEncoder = (deck: Deck) => ({
+const deckEncoder = (deck: Pick<Deck, 'id' | 'name' | 'updated'>) => ({
   id: deck.id,
   name: deck.name,
-  updated_ago: dayjs(deck.updated).fromNow(),
+  updated: dayjs(deck.updated).toISOString(),
 });
 
 export default deckEncoder;

--- a/src/encoders/player.encoder.ts
+++ b/src/encoders/player.encoder.ts
@@ -1,6 +1,6 @@
-import { Player } from '@prisma/client';
+import type { Player } from '@prisma/client';
 
-const playerEncoder = (player: Player) => ({
+const playerEncoder = (player: Pick<Player, 'id' | 'first_name' | 'last_name' | 'avatar'>) => ({
   id: player.id,
   first_name: player.first_name,
   last_name: player.last_name,

--- a/src/types/deck.types.ts
+++ b/src/types/deck.types.ts
@@ -34,3 +34,17 @@ export type DeckValidationErrors = {
   sideboardSize: boolean,
   deckSize: boolean,
 }
+
+export type DeckListRaw = {
+  deck_id: Deck['id'];
+  deck_name: Deck['name'];
+  deck_player_id: Deck['player_id'];
+  deck_created: Deck['created'];
+  deck_updated: Deck['updated'];
+  player_id: Player['id'];
+  player_email: Player['email'];
+  player_first_name: Player['first_name'];
+  player_last_name: Player['last_name'];
+  player_avatar: Player['avatar'];
+  total_cards: number;
+}


### PR DESCRIPTION
## What is the change you are proposing?
Add a raw query to return the data required to list decks, their player and also the number of cards present in the deck

## Why is this change needed?
The Prisma ORM doesn't support using `SUM()` on an associated field like this. Only when directly querying a single model and grouping by the property to be counted.

## Does this resolve any issues?
Resolves #37 
